### PR TITLE
ADD : 직무탐색 게시글 API 및 필터

### DIFF
--- a/controllers/postsController.js
+++ b/controllers/postsController.js
@@ -1,5 +1,20 @@
 const postsService = require('../services/postsService');
 
+const getPosts = async (req, res) => {
+  try {
+    const tag = req.query.tag || '';
+    const techStack = req.query.techStack || '';
+    const positionId = req.query.position || "''";
+    const location = req.query.location || null;
+    const career = req.query.career || null;
+    const result = await postsService.getPosts(tag, techStack, positionId, location, career);
+    res.status(200).json(result);
+  } catch (err) {
+    console.log(err);
+    res.status(400).json({ message: err.message });
+  }
+}
+
 const getPostsPage = async (req, res) => {
   try {
     const postsId = req.params.id;
@@ -7,9 +22,9 @@ const getPostsPage = async (req, res) => {
     res.status(200).json(postpage);
   } catch (err) {
     console.log(err);
-    res.status(err.statusCode).json({ message: err.message });
-  }
-}
+    res.status(400).json({ message: err.message });
+  };
+};
 
 
-module.exports = { getPostsPage };
+module.exports = { getPosts, getPostsPage };

--- a/models/postsDao.js
+++ b/models/postsDao.js
@@ -1,9 +1,448 @@
 const myDataSource = require('../middlewares/typeorm');
 
+const responseFastCompany = async () => {
+  let asapCompany = await myDataSource.query(`
+  SELECT
+    posts.id as postsId, co.images, co.company_name, posts.title, ps.tech_stacks, co.location,
+    posts.career_min, career_max, view, posts.due_date, posts.position_id, posts.company_id
+  FROM posts
+  LEFT JOIN (
+      SELECT
+    posts_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", tech_stack.id,
+      "tech_stack", tech_stack.tech_stack_name
+      )
+    ) as tech_stacks
+    FROM
+      posts_tech_stack
+    JOIN
+      tech_stack ON posts_tech_stack.tech_stack_id = tech_stack.id
+    GROUP BY
+      posts_id
+  ) ps ON posts.id = ps.posts_id
+  LEFT JOIN education
+    ON education.id = posts.education_id
+  LEFT JOIN (
+  SELECT
+    company.id, company.company_name, ct.tags, ci.images, company.location
+  FROM company
+  LEFT JOIN (
+    SELECT
+      company_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", id,
+      "image", image
+      )
+    ) as images
+    FROM
+      image
+    GROUP BY
+      company_id
+  ) as ci ON company.id = ci.company_id
+  LEFT JOIN (
+    SELECT
+      company_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", tag.id,
+      "tag", tag.tag_name
+      )
+    ) as tags
+    FROM
+      company_tag
+    JOIN
+      tag ON company_tag.tag_id = tag.id
+    GROUP BY
+      company_id
+    ) ct ON company.id = ct.company_id
+  )as co ON co.id = posts.company_id
+  WHERE tags LIKE '%지원 응답%'
+  ORDER BY RAND()
+  LIMIT 8;
+`);
+
+  asapCompany = [...asapCompany].map(item => {
+    return {
+      ...item,
+      images: JSON.parse(item.images),
+      tech_stacks: JSON.parse(item.tech_stacks),
+    };
+  });
+
+  return asapCompany;
+};
+
+const allPosts = async () => {
+  let allPost = await myDataSource.query(`
+  SELECT
+    posts.id as postsId, co.images, co.company_name, posts.title, ps.tech_stacks,
+    co.location, posts.career_min, career_max, view, posts.position_id
+  FROM posts
+  LEFT JOIN (
+    SELECT
+      posts_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", posts_tech_stack.id,
+      "tech_stack", tech_stack.tech_stack_name
+      )
+    ) as tech_stacks
+    FROM
+      posts_tech_stack
+    JOIN
+      tech_stack ON posts_tech_stack.tech_stack_id = tech_stack.id
+    GROUP BY
+      posts_id
+  ) ps ON posts.id = ps.posts_id
+  LEFT JOIN education
+  ON education.id = posts.education_id
+  LEFT JOIN (
+    SELECT
+      company.id, company.company_name, ci.images, company.location
+    FROM company
+    LEFT JOIN (
+      SELECT
+        company_id,
+      JSON_ARRAYAGG(
+        JSON_OBJECT(
+        "id", id,
+        "image", image
+        )
+      ) as images
+      FROM
+        image
+      GROUP BY
+        company_id
+    ) as ci ON company.id = ci.company_id
+  )as co ON co.id = posts.company_id
+  ORDER BY posts.created_at DESC;
+`)
+
+  allPost = [...allPost].map(item => {
+    return {
+      ...item,
+      images: JSON.parse(item.images),
+      tech_stacks: JSON.parse(item.tech_stacks),
+    };
+  });
+
+  return allPost
+}
+
+const tagPosts = async tags => {
+  let tagPost = await myDataSource.query(`
+  SELECT
+    posts.id as postsId, co.images, co.company_name, posts.title, ps.tech_stacks,
+    co.location, posts.career_min, career_max, view, posts.position_id
+  FROM posts
+  LEFT JOIN (
+    SELECT
+      posts_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", tech_stack.id,
+      "tech_stack", tech_stack.tech_stack_name
+      )
+    ) as tech_stacks
+    FROM
+      posts_tech_stack
+    JOIN
+      tech_stack ON posts_tech_stack.tech_stack_id = tech_stack.id
+    GROUP BY
+        posts_id
+  ) ps ON posts.id = ps.posts_id
+  LEFT JOIN education
+  ON education.id = posts.education_id
+  LEFT JOIN (
+    SELECT
+      company.id, company.company_name, ct.tags, ci.images, company.location
+    FROM company
+  LEFT JOIN (
+    SELECT
+      company_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", id,
+      "image", image
+      )
+    ) as images
+    FROM
+      image
+    GROUP BY
+      company_id
+  ) as ci ON company.id = ci.company_id
+  LEFT JOIN (
+    SELECT
+      company_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", tag.id,
+        "tag", tag.tag_name
+      )
+    ) as tags
+    FROM
+      company_tag
+    JOIN
+      tag ON company_tag.tag_id = tag.id
+      WHERE tag.tag_name IN (${tags})
+    GROUP BY
+      company_id
+    HAVING COUNT(tag_id) >= '1'
+    ) ct ON company.id = ct.company_id
+  )as co ON co.id = posts.company_id
+  WHERE NOT tags is NULL
+`)
+
+  tagPost = [...tagPost].map(item => {
+    return {
+      ...item,
+      images: JSON.parse(item.images),
+      tech_stacks: JSON.parse(item.tech_stacks),
+    };
+  });
+
+  return tagPost;
+};
+
+const techStackPosts = async techStacks => {
+  let techStackPost = await myDataSource.query(`
+  SELECT
+    posts.id as postsId, co.images, co.company_name, posts.title, ps.tech_stacks,
+    co.location, posts.career_min, career_max, view, posts.position_id
+  FROM posts
+  LEFT JOIN (
+    SELECT
+      posts_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", posts_tech_stack.id,
+      "tech_stack", tech_stack.tech_stack_name
+      )
+    ) as tech_stacks
+    FROM
+      posts_tech_stack
+    JOIN
+      tech_stack ON posts_tech_stack.tech_stack_id = tech_stack.id
+    WHERE tech_stack.tech_stack_name IN (${techStacks})
+    GROUP BY
+      posts_id
+    HAVING COUNT(tech_stack_id) >= 1
+  ) ps ON posts.id = ps.posts_id
+  LEFT JOIN education
+  ON education.id = posts.education_id
+  LEFT JOIN (
+    SELECT
+      company.id, company.company_name, ci.images, company.location
+    FROM company
+    LEFT JOIN (
+      SELECT
+      company_id,
+      JSON_ARRAYAGG(
+        JSON_OBJECT(
+        "id", id,
+        "image", image
+        )
+      ) as images
+      FROM
+        image
+      GROUP BY
+        company_id
+    ) as ci ON company.id = ci.company_id
+  )as co ON co.id = posts.company_id
+  WHERE NOT tech_stacks is NULL
+`);
+
+  techStackPost = [...techStackPost].map(item => {
+    return {
+      ...item,
+      images: JSON.parse(item.images),
+      tech_stacks: JSON.parse(item.tech_stacks),
+    };
+  });
+
+  return techStackPost;
+};
+
+const positionPosts = async positionId => {
+  let positionPost = await myDataSource.query(`
+  SELECT
+    posts.id as postsId, co.images, co.company_name, posts.title, ps.tech_stacks,
+    co.location, posts.career_min, career_max, view, posts.position_id
+  FROM posts
+  LEFT JOIN (
+    SELECT
+      posts_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", posts_tech_stack.id,
+      "tech_stack", tech_stack.tech_stack_name
+      )
+    ) as tech_stacks
+    FROM
+      posts_tech_stack
+    JOIN
+      tech_stack ON posts_tech_stack.tech_stack_id = tech_stack.id
+    GROUP BY
+      posts_id
+  ) ps ON posts.id = ps.posts_id
+  LEFT JOIN education
+  ON education.id = posts.education_id
+  LEFT JOIN (
+    SELECT
+      company.id, company.company_name, ci.images, company.location
+    FROM company
+    LEFT JOIN (
+      SELECT
+      company_id,
+      JSON_ARRAYAGG(
+        JSON_OBJECT(
+        "id", id,
+        "image", image
+        )
+      ) as images
+      FROM
+        image
+      GROUP BY
+        company_id
+    ) as ci ON company.id = ci.company_id
+  )as co ON co.id = posts.company_id
+WHERE position_id IN (${positionId})
+`);
+
+  positionPost = [...positionPost].map(item => {
+    return {
+      ...item,
+      images: JSON.parse(item.images),
+      tech_stacks: JSON.parse(item.tech_stacks),
+    };
+  });
+
+  return positionPost;
+};
+
+const locationPosts = async location => {
+  let locationPost = await myDataSource.query(`
+  SELECT
+    posts.id as postsId, co.images, co.company_name, posts.title, ps.tech_stacks,
+    co.location, posts.career_min, career_max, view, posts.position_id
+  FROM posts
+  LEFT JOIN (
+    SELECT
+      posts_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", posts_tech_stack.id,
+      "tech_stack", tech_stack.tech_stack_name
+      )
+    ) as tech_stacks
+    FROM
+      posts_tech_stack
+    JOIN
+      tech_stack ON posts_tech_stack.tech_stack_id = tech_stack.id
+    GROUP BY
+      posts_id
+  ) ps ON posts.id = ps.posts_id
+  LEFT JOIN education
+  ON education.id = posts.education_id
+  LEFT JOIN (
+    SELECT
+      company.id, company.company_name, ci.images, company.location
+    FROM company
+    LEFT JOIN (
+      SELECT
+        company_id,
+      JSON_ARRAYAGG(
+        JSON_OBJECT(
+        "id", id,
+        "image", image
+        )
+      ) as images
+      FROM
+        image
+      GROUP BY
+        company_id
+    ) as ci ON company.id = ci.company_id
+  )as co ON co.id = posts.company_id
+  WHERE location LIKE '%${location}%';
+`);
+
+  locationPost = [...locationPost].map(item => {
+    return {
+      ...item,
+      images: JSON.parse(item.images),
+      tech_stacks: JSON.parse(item.tech_stacks),
+    };
+  });
+
+  return locationPost;
+};
+
+const careerPosts = async career => {
+  let careerPost = await myDataSource.query(`
+  SELECT
+    posts.id as postsId, co.images, co.company_name, posts.title, ps.tech_stacks,
+    co.location, posts.career_min, career_max, view, posts.position_id
+  FROM posts
+  LEFT JOIN (
+    SELECT
+      posts_id,
+    JSON_ARRAYAGG(
+      JSON_OBJECT(
+      "id", posts_tech_stack.id,
+      "tech_stack", tech_stack.tech_stack_name
+      )
+    ) as tech_stacks
+    FROM
+      posts_tech_stack
+    JOIN
+      tech_stack ON posts_tech_stack.tech_stack_id = tech_stack.id
+    GROUP BY
+      posts_id
+  ) ps ON posts.id = ps.posts_id
+  LEFT JOIN education
+  ON education.id = posts.education_id
+  LEFT JOIN (
+    SELECT
+      company.id, company.company_name, ci.images, company.location
+    FROM company
+    LEFT JOIN (
+      SELECT
+      company_id,
+      JSON_ARRAYAGG(
+        JSON_OBJECT(
+        "id", id,
+        "image", image
+        )
+      ) as images
+      FROM
+        image
+      GROUP BY
+        company_id
+    ) as ci ON company.id = ci.company_id
+  )as co ON co.id = posts.company_id
+  HAVING career_min <= ${career} AND ${career} <= career_max
+`);
+
+  careerPost = [...careerPost].map(item => {
+    return {
+      ...item,
+      images: JSON.parse(item.images),
+      tech_stacks: JSON.parse(item.tech_stacks),
+    };
+  });
+
+  return careerPost;
+};
+
+
 const getPostsPage = async postsId => {
   let postsPage = await myDataSource.query(`
   SELECT
-    posts.id, posts.title, ps.tech_stacks, posts.content, posts.career_min, career_max, education_name, posts.due_date
+    posts.id as postsId, posts.title, ps.tech_stacks, posts.content,
+    posts.career_min, career_max, education_name, posts.due_date
   FROM posts
   LEFT JOIN (
     SELECT
@@ -33,6 +472,7 @@ const getPostsPage = async postsId => {
   });
 
   let postPageInfo = { postsPage };
+
   return postPageInfo;
 }
 
@@ -45,7 +485,7 @@ const findCompanyId = async postsId => {
 }
 
 const postsInCompany = async companyId => {
-  let company = await myDataSource.query(`
+  let companyInfo = await myDataSource.query(`
   SELECT
     company.id, company.company_name, ct.tags, ci.images, company.location
   FROM company
@@ -82,7 +522,8 @@ const postsInCompany = async companyId => {
   WHERE id = '${companyId}'
   GROUP BY company.id
 `);
-  company = [...company].map(item => {
+
+  companyInfo = [...companyInfo].map(item => {
     return {
       ...item,
       tags: JSON.parse(item.tags),
@@ -90,7 +531,6 @@ const postsInCompany = async companyId => {
     };
   });
 
-  const companyInfo = { company };
   return companyInfo;
 }
 
@@ -98,13 +538,14 @@ const findPostionId = async postsId => {
   const [positionId] = await myDataSource.query(`
   SELECT position_id FROM posts WHERE id = '${postsId}'
   `)
+
   return positionId;
 }
 
 const samePositionPosts = async positionId => {
   let positionPosts = await myDataSource.query(`
   SELECT
-    posts.id, co.images, co.company_name, posts.title, ps.tech_stacks,
+    posts.id as postsId, co.images, co.company_name, posts.title, ps.tech_stacks,
     co.location, posts.career_min, career_max, view, posts.position_id
   FROM posts
   LEFT JOIN (
@@ -149,6 +590,7 @@ const samePositionPosts = async positionId => {
   WHERE position_id = '${positionId}'
   LIMIT 8
   `);
+
   positionPosts = [...positionPosts].map(item => {
     return {
       ...item,
@@ -156,6 +598,7 @@ const samePositionPosts = async positionId => {
       tech_stacks: JSON.parse(item.tech_stacks),
     };
   });
+
   return positionPosts;
 }
 
@@ -163,10 +606,22 @@ const addView = async postsId => {
   const viewCount = await myDataSource.query(`
   UPDATE posts SET view = view + 1 WHERE id = '${postsId}'
   `);
+
   return viewCount;
 }
 
 module.exports = {
-  getPostsPage, findCompanyId, postsInCompany,
-  findPostionId, samePositionPosts, addView
+  responseFastCompany,
+  allPosts,
+  tagPosts,
+  techStackPosts,
+  positionPosts,
+  locationPosts,
+  careerPosts,
+  getPostsPage,
+  findCompanyId,
+  postsInCompany,
+  findPostionId,
+  samePositionPosts,
+  addView
 };

--- a/routes/postsRouter.js
+++ b/routes/postsRouter.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const postsController = require('../controllers/postsController');
 
 
+router.get('/', postsController.getPosts);
 router.get('/:id', postsController.getPostsPage);
 
 module.exports = router;

--- a/services/postsService.js
+++ b/services/postsService.js
@@ -1,4 +1,140 @@
 const postsDao = require('../models/postsDao');
+var _ = require('lodash');
+
+const getPosts = async (tag, techStack, positionId, location, career) => {
+  let tags = [];
+  if (typeof (tag) == 'string') {
+    tags.push(`"${tag}"`);
+  } else if (tag !== undefined && tag.length > 1) {
+    for (let i = 0; i < tag.length; i++) {
+      tags.push(`"${tag[i]}"`);
+    }
+  }
+  if (tags.length > 1) {
+    tags = tags.join(",");
+  } else {
+    tags = tags[0];
+  }
+
+  let techStacks = [];
+  if (typeof (techStack) == 'string') {
+    techStacks.push(`"${techStack}"`);
+  } else if (techStack !== undefined && techStack.length > 1) {
+    for (let i = 0; i < tag.length; i++) {
+      techStacks.push(`"${techStack[i]}"`);
+    };
+  };
+  if (techStacks.length > 1) {
+    techStacks = techStacks.join(",");
+  } else {
+    techStacks = techStacks[0];
+  };
+
+  let positionIds = [];
+  if (typeof (positionId) == 'string') {
+    positionIds.push(`"${techStack}"`);
+  } else if (positionId !== undefined && positionId.length > 1) {
+    for (let i = 0; i < tag.length; i++) {
+      positionIds.push(`"${techStack[i]}"`);
+    };
+  };
+  if (positionIds.length > 1) {
+    positionIds = positionIds.join(",");
+  } else {
+    positionIds = positionIds[0];
+  };
+  const responseFastCompany = await postsDao.responseFastCompany();
+  const allPosts = await postsDao.allPosts();
+  const tagPosts = await postsDao.tagPosts(tags);
+  const techStackPosts = await postsDao.techStackPosts(techStacks);
+  const positionPosts = await postsDao.positionPosts(positionId);
+  const locationPosts = await postsDao.locationPosts(location);
+  const careerPosts = await postsDao.careerPosts(career);
+
+  let filterPosts =
+    { tagPosts, techStackPosts, positionPosts, locationPosts, careerPosts };
+
+  filterPosts = filterPosts.tagPosts.concat(
+    filterPosts.techStackPosts, filterPosts.positionPosts,
+    filterPosts.locationPosts, filterPosts.careerPosts
+  );
+  filterPosts = _.uniqBy(filterPosts, 'postsId');
+
+  let tagAndTechStackPost = [];
+  if (tagPosts.length !== 0 && techStackPosts.length !== 0) {
+    for (let i = 0; i < tagPosts.length; i++) {
+      for (let j = 0; j < techStackPosts.length; j++) {
+        if (tagPosts[i].postsId === techStackPosts[j].postsId) {
+          tagAndTechStackPost.push(tagPosts[i]);
+        }
+      }
+    }
+  };
+
+  const strAllPosts = allPosts.map(JSON.stringify);
+  const strPositionPosts = positionPosts.map(JSON.stringify);
+  const strLocationPosts = locationPosts.map(JSON.stringify);
+  const strCareerPosts = careerPosts.map(JSON.stringify);
+
+  let anotherPost = strAllPosts;
+
+  if (strPositionPosts.length !== 0) {
+    anotherPost = anotherPost.filter(el => strPositionPosts.includes(el));
+  };
+  if (strLocationPosts.length !== 0) {
+    anotherPost = anotherPost.filter(el => strLocationPosts.includes(el));
+  };
+  if (strCareerPosts.length !== 0) {
+    anotherPost = anotherPost.filter(el => strCareerPosts.includes(el));
+  };
+  anotherPost = anotherPost.map(JSON.parse);
+
+  let result = [];
+
+  if (tagAndTechStackPost.length !== 0) {
+    for (let i = 0; i < anotherPost.length; i++) {
+      for (let j = 0; j < tagAndTechStackPost.length; j++) {
+        if (anotherPost[i].postsId === tagAndTechStackPost[j].postsId) {
+          result.push(tagAndTechStackPost[j]);
+        }
+      }
+    }
+  };
+
+  if (techStackPosts.length === 0 && tagPosts.length !== 0) {
+    for (let i = 0; i < anotherPost.length; i++) {
+      for (let j = 0; j < tagPosts.length; j++) {
+        if (anotherPost[i].postsId === tagPosts[j].postsId) {
+          result.push(tagPosts[j]);
+        }
+      }
+    }
+  };
+
+  if (techStackPosts.length !== 0 && tagPosts.length === 0){
+    for (let i = 0; i < anotherPost.length; i++) {
+      for (let j = 0; j < techStackPosts.length; j++) {
+        if (anotherPost[i].postsId === techStackPosts[j].postsId) {
+          result.push(techStackPosts[j]);
+        }
+      }
+    }
+  };
+
+  if (techStackPosts.length === 0 && tagPosts.length === 0) {
+    result = anotherPost;
+  };
+
+  if (result.length === 0) {
+    throw new Error('게시글이 없습니다.');
+  };
+
+  if (filterPosts.length === 0) {
+    result = { responseFastCompany, allPosts }
+  };
+
+  return { result };
+}
 
 const getPostsPage = async postsId => {
   const postsPage = await postsDao.getPostsPage(postsId);
@@ -13,4 +149,4 @@ const getPostsPage = async postsId => {
   return result;
 }
 
-module.exports = { getPostsPage };
+module.exports = { getPosts, getPostsPage };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 직무탐색 페이지 게시글 API
- 직무탐색 페이지 필터

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 직무탐색 페이지 게시글 API

- /posts GET 요청 시 게시글 데이터를 최신에 등록된 것이 먼저 보여줍니다.

2. 직무탐색 페이지 필터링 기능

- 조건문과 filter함수를 통해 필터링 기능
- 필터링에 해당 되지 않아 게시글이 없다면 에러처리로 유효성 처리

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 필터링 기능을 사용하여 알고리즘에 대해 조금 알 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항

- 통신 시 에러 나면 수정하겠습니다
